### PR TITLE
Feat: Allow users to favorite stores and view them on profile

### DIFF
--- a/data/stores.js
+++ b/data/stores.js
@@ -39,12 +39,13 @@ export function editStore(store) {
 }
 
 export function favoriteStore(storeId) {
-  return fetchWithoutResponse(`stores/${storeId}/favorite`, {
+  return fetchWithoutResponse(`profile/favoritesellers`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
-    },
+     },
+    body: JSON.stringify({ store_id: storeId })
   })
 }
 

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -23,7 +23,7 @@ export default function Profile() {
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.favorites?.map(favorite => (
+            profile.favorite_stores?.map(favorite => (
               <StoreCard store={favorite} key={favorite.id} width="is-one-third" />
             ))
           }


### PR DESCRIPTION
Feature: Favorite Stores in Profile

---

##  Changes
- Added favorite/unfavorite button to store detail view (UI already existed, now functional)
- Connected `favoriteStore` and `unfavoriteStore` fetch functions to backend API
- Passed `is_favorite` value into store detail buttons
- Updated `Profile` component to render favorite stores
- Used `StoreCard` to display each favorited store on the profile page

---

##  Requests / Responses

**POST** `/profile/favoritesellers`  
Favorites a store

**Request:**

```json
{
  "store_id": 3
}

Response: 

{
  "id": 1,
  "seller": {
    "id": 4,
    "url": "http://localhost:8000/customers/4",
    "user": {
      "first_name": "Steve",
      "last_name": "Brownlee",
      "username": "steve"
    }
  }
}