### PR TITLE
Likeproducts

### DIFF
--- a/data/products.js
+++ b/data/products.js
@@ -129,8 +129,8 @@ export function likeProduct(productId) {
   });
 }
 
-export function unLikeProduct(productId) {
-  return fetchWithoutResponse(`products/${productId}/unlike`, {
+export function unlikeProduct(productId) {
+  return fetchWithoutResponse(`products/${productId}/like`, {
     method: "DELETE",
     headers: {
       Authorization: `Token ${localStorage.getItem("token")}`,
@@ -138,3 +138,4 @@ export function unLikeProduct(productId) {
     },
   });
 }
+

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -1,37 +1,34 @@
 import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import Layout from '../../../components/layout'
 import Navbar from '../../../components/navbar'
 import { Detail } from '../../../components/product/detail'
 import { Ratings } from '../../../components/rating/detail'
-import { getProductById, likeProduct, unLikeProduct } from '../../../data/products'
+import { getProductById, likeProduct, unlikeProduct } from '../../../data/products'
 
 export default function ProductDetail() {
   const router = useRouter()
   const { id } = router.query
   const [product, setProduct] = useState({})
 
-  const refresh = () => {
+  const refresh = useCallback(() => {
+    if (!id) return
     getProductById(id).then(productData => {
-      if (productData) {
-        setProduct(productData)
-      }
+      if (productData) setProduct(productData)
     })
-  }
+  }, [id])
 
-  const like = () => {
+  const like = useCallback(() => {
     likeProduct(id).then(refresh)
-  }
+  }, [id, refresh])
 
-  const unlike = () => {
-    unLikeProduct(id).then(refresh)
-  }
+  const unlike = useCallback(() => {
+    unlikeProduct(id).then(refresh)
+  }, [id, refresh])
 
   useEffect(() => {
-    if (id) {
-      refresh()
-    }
-  }, [id])
+    refresh()
+  }, [refresh])
 
   return (
     <div className="columns is-centered">


### PR DESCRIPTION

## Add Like/Unlike Button Toggle for Products  

**Changes:**  
- Implemented like/unlike toggle in product detail view  
- Updated data layer to use correct endpoint names (`likeProduct` / `unlikeProduct`)  
- Adjusted React `useCallback` + `useEffect` hooks to handle state updates cleanly  
- Confirmed button text and icon swap between "Like Product" and "Unlike Product" based on `is_liked` flag  

**Requests/Responses (relevant):**  
**POST `/products/:id/like`**  
Request: *No body required*  
Response: **201 Created**  

**DELETE `/products/:id/like`**  
Request: *No body required*  
Response: **204 No Content**  

**GET `/products/:id`**  
Response includes:  
```json
{
  "id": 2,
  "name": "Example Product",
  "price": 29.99,
  "is_liked": true
}
