### PR TITLE
Bb recent category items

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { getCategories } from "../data/products";
 import { Input, Select } from "./form-elements";
 
-export default function Filter({ productCount, onSearch, locations }) {
+export default function Filter({ productCount, onSearch, locations, showFilters, setShowFilters }) {
   const refEls = {
     location: useRef(),
     category: useRef(),
@@ -13,7 +13,6 @@ export default function Filter({ productCount, onSearch, locations }) {
     number_sold: useRef(),
   };
 
-  const [showFilters, setShowFilters] = useState(false);
   const [query, setQuery] = useState("");
   const [categories, setCategories] = useState([]);
   const [direction, setDirection] = useState("asc");

--- a/data/products.js
+++ b/data/products.js
@@ -1,4 +1,3 @@
-import { headers } from 'next/headers'
 import { fetchWithResponse, fetchWithoutResponse } from './fetcher'
 
 export function getProducts(query=undefined) {

--- a/data/products.js
+++ b/data/products.js
@@ -1,3 +1,4 @@
+import { headers } from 'next/headers'
 import { fetchWithResponse, fetchWithoutResponse } from './fetcher'
 
 export function getProducts(query=undefined) {
@@ -16,6 +17,14 @@ export function getProducts(query=undefined) {
 
 export function getCategories() {
   return fetchWithResponse('categories', {
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`
+    }
+  })
+}
+
+export function getRecentProductsByCategory() {
+  return fetchWithResponse('productscategories?incluede_recent_products=true', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }

--- a/data/products.js
+++ b/data/products.js
@@ -22,12 +22,12 @@ export function getCategories() {
   })
 }
 
-export function getRecentProductsByCategory() {
-  return fetchWithResponse('productscategories?incluede_recent_products=true', {
+export function getAllCategoriesWithRecentProducts() {
+  return fetchWithResponse('productcategories?include_recent_products=true', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
-  })
+  });
 }
 
 export function getProductById(id) {

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -3,13 +3,14 @@ import Filter from "../../components/filter";
 import Layout from "../../components/layout";
 import Navbar from "../../components/navbar";
 import { ProductCard } from "../../components/product/card";
-import { getProducts } from "../../data/products";
+import { getCategories, getProducts } from "../../data/products";
 
 export default function Products() {
   const [products, setProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadingMessage, setLoadingMessage] = useState("Loading products...");
   const [locations, setLocations] = useState([]);
+  const [categories, setCategories] = useState([])
 
   useEffect(() => {
     getProducts()
@@ -35,6 +36,30 @@ export default function Products() {
       });
   }, []);
 
+  useEffect(() => {
+    getCategories().then((data) => {
+      if (data) {
+        setCategories(data);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    getRecentProductsByCategory()
+      .then((data) => {
+        if (data) {
+          setCategoriesWithProducts(data);
+        }
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        setLoadingMessage(
+          `Unable to retrieve recent products. Status code ${err.message} on response.`
+        );
+        setIsLoading(false);
+      });
+  }, []);
+
   const searchProducts = useCallback((event) => {
     getProducts(event).then((productsData) => {
       if (productsData) {
@@ -52,6 +77,30 @@ export default function Products() {
         onSearch={searchProducts}
         locations={locations}
       />
+      
+      <div className="columns is-multiline">
+        {categories.map((category) => {
+          const categoryProducts = products
+            .filter((product) => product.category_id === category.id)
+            .slice(-5)
+
+          return (
+            <div className="column is-half" key={category.id}>
+              <div className="box has-text-centered">
+                <strong>{category.name}</strong>
+              </div>
+              {categoryProducts.length > 0 ? (
+                categoryProducts.map((product) => (
+                  <ProductCard product={product} key={product.id} />
+                ))
+              ) : (
+                <p className="has-text-centered is-italic">No products in category</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
 
       <div className="columns is-multiline">
         {products.map((product) => (

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -3,8 +3,7 @@ import Filter from "../../components/filter";
 import Layout from "../../components/layout";
 import Navbar from "../../components/navbar";
 import { ProductCard } from "../../components/product/card";
-import { getCategories, getProducts } from "../../data/products";
-import { getRecentProductsByCategory } from "../../data/products";
+import { getAllCategoriesWithRecentProducts, getCategories, getProducts } from "../../data/products";
 
 export default function Products() {
   const [products, setProducts] = useState([]);
@@ -12,7 +11,8 @@ export default function Products() {
   const [loadingMessage, setLoadingMessage] = useState("Loading products...");
   const [locations, setLocations] = useState([]);
   const [categories, setCategories] = useState([])
-
+  const [categoriesWithProducts, setCategoriesWithProducts] = useState([]);
+  const [productsByCategory, setProductsByCategory] = useState({});
   useEffect(() => {
     getProducts()
       .then((data) => {
@@ -46,10 +46,15 @@ export default function Products() {
   }, []);
 
   useEffect(() => {
-    getRecentProductsByCategory()
+    getAllCategoriesWithRecentProducts()
       .then((data) => {
         if (data) {
           setCategoriesWithProducts(data);
+          const grouped = {};
+          data.forEach(category => {
+            grouped[category.id] = category.products || [];
+          });
+          setProductsByCategory(grouped);
         }
         setIsLoading(false);
       })
@@ -60,6 +65,7 @@ export default function Products() {
         setIsLoading(false);
       });
   }, []);
+
 
   const searchProducts = useCallback((event) => {
     getProducts(event).then((productsData) => {
@@ -78,24 +84,27 @@ export default function Products() {
         onSearch={searchProducts}
         locations={locations}
       />
-      
+
       <div className="columns is-multiline">
         {categories.map((category) => {
-          const categoryProducts = getCategories
-          
+          const categoryProducts = productsByCategory[category.id] || [];
 
           return (
-            <div className="column is-half" key={category.id}>
+            <div className="column is-full" key={category.id}>
               <div className="box has-text-centered">
                 <strong>{category.name}</strong>
               </div>
-              {categoryProducts.length > 0 ? (
-                categoryProducts.map((product) => (
-                  <ProductCard product={product} key={product.id} />
-                ))
-              ) : (
-                <p className="has-text-centered is-italic">No products in category</p>
-              )}
+              <p className="has-text-centered">Latest Products</p>
+
+              <div className="columns is-multiline">
+                {categoryProducts.length > 0 ? (
+                  categoryProducts.map((product) => (
+                    <ProductCard product={product} key={product.id} width="is-one-quarter" />
+                  ))
+                ) : (
+                  <p className="has-text-centered is-italic">No products in category</p>
+                )}
+              </div>
             </div>
           );
         })}

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -13,6 +13,8 @@ export default function Products() {
   const [categories, setCategories] = useState([])
   const [categoriesWithProducts, setCategoriesWithProducts] = useState([]);
   const [productsByCategory, setProductsByCategory] = useState({});
+  const [showFilters, setShowFilters] = useState(false);
+
   useEffect(() => {
     getProducts()
       .then((data) => {
@@ -83,37 +85,54 @@ export default function Products() {
         productCount={products.length}
         onSearch={searchProducts}
         locations={locations}
+        showFilters={showFilters}
+        setShowFilters={setShowFilters}
       />
-      if(showFilters){
-        
-      }
+      {!showFilters && (
+        <div className="columns is-multiline">
+          {categories.map((category) => {
+            const categoryProducts = productsByCategory[category.id] || [];
+
+            return (
+              <div className="column is-full" key={category.id}>
+                <div className="box has-text-centered has-background-warning-light">
+                  <h2 className="title is-4"><strong>{category.name}</strong></h2>
+                </div>
+                <h3 className="title is-5 has-text-centered ">Latest Products</h3>
+
+                <div className="columns is-multiline has-background-grey-lighter">
+                  {categoryProducts.length > 0 ? (
+                    categoryProducts.map((product) => (
+                      <ProductCard product={product} key={product.id} width="is-one-fifth" />
+                    ))
+                  ) : (
+                    <div className="block">
+                      <h3 className=" title has-text-centered is-italic is-4">No products in category</h3>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+
       <div className="columns is-multiline">
-        {categories.map((category) => {
-          const categoryProducts = productsByCategory[category.id] || [];
-
-          return (
-            <div className="column is-full" key={category.id}>
-              <div className="box has-text-centered">
-                <strong>{category.name}</strong>
-              </div>
-              <p className="has-text-centered">Latest Products</p>
-
-              <div className="columns is-multiline">
-                {categoryProducts.length > 0 ? (
-                  categoryProducts.map((product) => (
-                    <ProductCard product={product} key={product.id} width="is-one-fifth" />
-                  ))
-                ) : (
-                  <p className="has-text-centered is-italic">No products in category</p>
-                )}
-              </div>
+        {showFilters && (
+          <div className="column is-full">
+            <div className="box has-text-centered is-full has-background-warning-light">
+              <h2 className="title is-4"><strong>Filtered Products</strong></h2>
             </div>
-          );
-        })}
-      </div>
+          </div>)}
+        {!showFilters && (
+          <div className="column is-full">
+            <div className="box has-text-centered is-full has-background-warning-light">
+              <h2 className="title is-4"><strong>All Products</strong></h2>
+            </div>
+          </div>)}
 
 
-      <div className="columns is-multiline">
         {products.map((product) => (
           <ProductCard product={product} key={product.id} />
         ))}

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -84,7 +84,9 @@ export default function Products() {
         onSearch={searchProducts}
         locations={locations}
       />
-
+      if(showFilters){
+        
+      }
       <div className="columns is-multiline">
         {categories.map((category) => {
           const categoryProducts = productsByCategory[category.id] || [];
@@ -99,7 +101,7 @@ export default function Products() {
               <div className="columns is-multiline">
                 {categoryProducts.length > 0 ? (
                   categoryProducts.map((product) => (
-                    <ProductCard product={product} key={product.id} width="is-one-quarter" />
+                    <ProductCard product={product} key={product.id} width="is-one-fifth" />
                   ))
                 ) : (
                   <p className="has-text-centered is-italic">No products in category</p>

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -4,6 +4,7 @@ import Layout from "../../components/layout";
 import Navbar from "../../components/navbar";
 import { ProductCard } from "../../components/product/card";
 import { getCategories, getProducts } from "../../data/products";
+import { getRecentProductsByCategory } from "../../data/products";
 
 export default function Products() {
   const [products, setProducts] = useState([]);
@@ -80,9 +81,8 @@ export default function Products() {
       
       <div className="columns is-multiline">
         {categories.map((category) => {
-          const categoryProducts = products
-            .filter((product) => product.category_id === category.id)
-            .slice(-5)
+          const categoryProducts = getCategories
+          
 
           return (
             <div className="column is-half" key={category.id}>


### PR DESCRIPTION
Feature: Initial product view should list 5 most recently added items in each category
https://github.com/NSS-Day-Cohort-76/Bangazon-client-xvvkkq/issues/64

Given a user has authenticated
When the product list should appear
Then a category header for each product category
And the five most recent products that have been added to the system should be listed under each header

Given the user is viewing the product list
When any filter is applied
Then the category headers will not be rendered
And any products that match the filter will be listed under a header labeled "Products matching filters"

3 Changes

   
**pages/products/index.js** : Added conditional rendering to show all categories and  5 recently listed items per category, but hide them if a filter is selected
**data/products.js** : added function getAllCategoriesWithRecentProducts() to fetch categories with recently posted products
**components/filter.js** : added props showFilters, setShowFilters  to filter function

